### PR TITLE
Fix duplicate header on calendar page

### DIFF
--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -1,5 +1,4 @@
 import { Calendar as CalendarIcon } from 'lucide-react';
-import { Header } from '@/components/Header';
 import { Footer } from '@/components/Footer';
 import CalendarClient from './CalendarClient';
 import { type CalendarEvent } from '@/lib/eventCategorization';
@@ -110,7 +109,6 @@ export default async function CalendarPage() {
 
   return (
     <div className="bg-stone-50">
-      <Header />
       {/* Hero Section */}
       <div className="bg-gradient-to-br from-teal-600 to-teal-800 text-white py-16">
         <div className="container mx-auto px-4">


### PR DESCRIPTION
## Summary
- fix /calendar displaying two headers by removing the page-level `<Header />` component

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6880f2ad1ba8832c95f15a54b3e97d60