### PR TITLE
Fix header sticky behavior

### DIFF
--- a/src/components/AnnouncementsSection.tsx
+++ b/src/components/AnnouncementsSection.tsx
@@ -151,7 +151,7 @@ export const AnnouncementsSection = () => {
         {/* Other Latest Posts Grid */}
         {otherPosts.length > 0 && (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-            {otherPosts.map((post: any, index: number) => (
+            {otherPosts.map((post: Record<string, unknown>, index: number) => (
               <BlogCard key={post.slug || index} {...post} variant="secondary" />
             ))}
           </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -14,10 +14,9 @@ export function Header() {
     { href: '/calendar', label: 'Calendar' },
   ];
   return (
-    <div>
-      <TopBar />
-      <header className="sticky top-0 z-50 border-b border-stone-200 bg-stone-50">
-        <nav className="container mx-auto px-4 py-4 flex items-center justify-between">
+  <header className="sticky top-0 z-50 border-b border-stone-200 bg-stone-50">
+    <TopBar />
+    <nav className="container mx-auto px-4 py-4 flex items-center justify-between">
           {/* Logo or Site Title */}
           <Link href="/" className="flex items-center space-x-2 text-xl text-serif font-semibold text-primary-800 dark:text-primary-200">
             {/* Wrap the Image and the div in a single parent element */}
@@ -90,6 +89,5 @@ export function Header() {
           </div>
         </nav>
       </header>
-    </div>
   );
 }


### PR DESCRIPTION
## Summary
- keep the top bar inside the sticky header
- fix type lint error in `AnnouncementsSection`

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_b_6880f566ad50832c86b2d9e2c37d4ecb