### PR TITLE
Fix header text visibility in dark mode

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,5 @@
 // src/components/Header.tsx
+import React from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { Button } from '@/components/ui/button';
@@ -14,11 +15,11 @@ export function Header() {
     { href: '/calendar', label: 'Calendar' },
   ];
   return (
-  <header className="sticky top-0 z-50 border-b border-stone-200 bg-stone-50">
+  <header className="sticky top-0 z-50 border-b border-stone-200 bg-stone-50 dark:bg-stone-900 dark:border-stone-700">
     <TopBar />
     <nav className="container mx-auto px-4 py-4 flex items-center justify-between">
           {/* Logo or Site Title */}
-          <Link href="/" className="flex items-center space-x-2 text-xl text-serif font-semibold text-primary-800 dark:text-primary-200">
+          <Link href="/" className="flex items-center space-x-2 text-xl text-serif font-semibold text-neutral-900 dark:text-neutral-100">
             {/* Wrap the Image and the div in a single parent element */}
             <> {/* This Fragment wraps the two direct children */}
               <Image


### PR DESCRIPTION
## Summary
- improve header contrast for dark theme
- add missing React import

## Testing
- `pnpm lint`
- `npx vitest run` *(fails: React is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_688122b956f4832c89f7ecac42252ea3