### PR TITLE
Fix dark mode header

### DIFF
--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -13,12 +13,14 @@ export function ThemeSwitcher() {
     const initialTheme = savedTheme || 'light'
     setTheme(initialTheme)
     document.documentElement.setAttribute('data-theme', initialTheme)
+    document.documentElement.classList.toggle('dark', initialTheme === 'dark')
   }, [])
 
   const toggleTheme = () => {
     const newTheme = theme === 'light' ? 'dark' : 'light'
     setTheme(newTheme)
     document.documentElement.setAttribute('data-theme', newTheme)
+    document.documentElement.classList.toggle('dark', newTheme === 'dark')
     localStorage.setItem('theme', newTheme)
   }
 


### PR DESCRIPTION
## Summary
- ensure `dark` class is toggled whenever theme changes

## Testing
- `pnpm install`
- `npx vitest run` *(fails: React not defined)*

------
https://chatgpt.com/codex/tasks/task_b_688129f57f80832c8ea4d97ef4e5673e