### PR TITLE
Add custom 404 page

### DIFF
--- a/src/app/calendar/CalendarClient.tsx
+++ b/src/app/calendar/CalendarClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { ChevronLeft, ChevronRight, Clock, MapPin, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { categorizeEvents, getAvailableCategories, type CalendarEvent } from '@/lib/eventCategorization';

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,25 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { Footer } from '@/components/Footer';
+
+export default function NotFound() {
+  return (
+    <main className="min-h-screen flex flex-col justify-between bg-[url('/assets/window.svg')] bg-cover text-center text-stone-800 dark:text-stone-100">
+      <div className="pt-20 pb-10 px-4">
+        <h1 className="text-4xl font-serif font-bold mb-4">Lost on the Path to St. Nicholas?</h1>
+        <h2 className="text-xl mb-8">Fear not, weary traveler! You’ve wandered off the trail, but St. Nicholas is here to guide you back.</h2>
+        <div className="mx-auto mb-8">
+          {/* Placeholder image until final artwork is available */}
+          <Image src="/assets/file.svg" alt="Placeholder icon" width={200} height={200} className="mx-auto" />
+        </div>
+        <p className="mb-6 max-w-xl mx-auto">It seems this page has slipped away like a candle’s flicker in the wind. While we search for it, explore these paths to reconnect with our community.</p>
+        <div className="flex justify-center gap-4 mb-12 flex-wrap">
+          <Link href="/" className="bg-yellow-700 text-white px-4 py-2 rounded hover:bg-yellow-800">Return to Our Parish</Link>
+          <Link href="/calendar" className="bg-red-700 text-white px-4 py-2 rounded hover:bg-red-800">Discover Our Services</Link>
+          <Link href="/contact" className="bg-blue-700 text-white px-4 py-2 rounded hover:bg-blue-800">Contact Our Clergy</Link>
+        </div>
+      </div>
+      <Footer />
+    </main>
+  );
+}

--- a/src/components/AdminCommentControls.tsx
+++ b/src/components/AdminCommentControls.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { MessageSquareOff, Loader2 } from 'lucide-react';
 

--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import React, { useState, useEffect } from 'react'
 import { Moon, Sun } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,4 +1,5 @@
 // src/components/TopBar.tsx
+import React from 'react';
 export function TopBar() {
   return (
     <div className="bg-gray-800 text-white py-2 text-center text-sm">


### PR DESCRIPTION
## Summary
- add a `not-found.tsx` page that displays a friendly 404 message and the site footer
- include React imports for several components so tests compile correctly
- swap to a placeholder icon in the 404 page

## Testing
- `pnpm lint`
- `npx vitest run` *(fails: Calendar responsive tests)*

------
https://chatgpt.com/codex/tasks/task_b_6883702673b0832c894ad632090f65d5