### PR TITLE
Fix lint errors in header tests

### DIFF
--- a/src/components/__tests__/Header.logo.test.tsx
+++ b/src/components/__tests__/Header.logo.test.tsx
@@ -1,27 +1,49 @@
+import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { Header } from '../Header';
-import { getHeaderConfig } from '@/lib/headerConfig';
 
 // Mock Next.js components
 jest.mock('next/link', () => {
-  return ({ children, href, ...props }: any) => (
+  const NextLinkMock = (
+    {
+      children,
+      href,
+      ...props
+    }: React.ComponentProps<'a'> & { href: string }
+  ) => (
     <a href={href} {...props}>
       {children}
     </a>
   );
+  NextLinkMock.displayName = 'NextLinkMock';
+  return NextLinkMock;
 });
 
 jest.mock('next/image', () => {
-  return ({ src, alt, width, height, className, ...props }: any) => (
-    <img 
-      src={src} 
-      alt={alt} 
-      width={width} 
-      height={height} 
+  const NextImageMock = (
+    {
+      src,
+      alt,
+      width,
+      height,
+      className,
+      ...props
+    }: Omit<React.ImgHTMLAttributes<HTMLImageElement>, 'src' | 'alt'> & {
+      src: string;
+      alt: string;
+    }
+  ) => (
+    <img
+      src={src}
+      alt={alt}
+      width={width}
+      height={height}
       className={className}
-      {...props} 
+      {...props}
     />
   );
+  NextImageMock.displayName = 'NextImageMock';
+  return NextImageMock;
 });
 
 // Mock the header config

--- a/src/components/__tests__/Header.mobile.test.tsx
+++ b/src/components/__tests__/Header.mobile.test.tsx
@@ -1,19 +1,39 @@
+import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { Header } from '../Header';
 
 // Mock Next.js components
 jest.mock('next/link', () => {
-  return ({ children, href, className, ...props }: any) => (
+  const NextLinkMock = (
+    {
+      children,
+      href,
+      className,
+      ...props
+    }: React.ComponentProps<'a'> & { href: string }
+  ) => (
     <a href={href} className={className} {...props}>
       {children}
     </a>
   );
+  NextLinkMock.displayName = 'NextLinkMock';
+  return NextLinkMock;
 });
 
 jest.mock('next/image', () => {
-  return ({ src, alt, className, ...props }: any) => (
-    <img src={src} alt={alt} className={className} {...props} />
-  );
+  const NextImageMock = (
+    {
+      src,
+      alt,
+      className,
+      ...props
+    }: Omit<React.ImgHTMLAttributes<HTMLImageElement>, 'src' | 'alt'> & {
+      src: string;
+      alt: string;
+    }
+  ) => <img src={src} alt={alt} className={className} {...props} />;
+  NextImageMock.displayName = 'NextImageMock';
+  return NextImageMock;
 });
 
 // Mock components
@@ -23,10 +43,12 @@ jest.mock('../TopBar', () => ({
 }));
 
 jest.mock('../MobileNav', () => ({
-  MobileNav: ({ navLinks }: { navLinks: any[] }) => (
+  MobileNav: ({ navLinks }: { navLinks: { href: string; label: string }[] }) => (
     <div data-testid="mobile-nav">
-      {navLinks.map(link => (
-        <a key={link.href} href={link.href}>{link.label}</a>
+      {navLinks.map((link) => (
+        <a key={link.href} href={link.href}>
+          {link.label}
+        </a>
       ))}
     </div>
   )


### PR DESCRIPTION
## Summary
- fix lint errors in Header.logo.test.tsx and Header.mobile.test.tsx
- add explicit types for mock components
- remove unused header config import

## Testing
- `pnpm lint`
- `npx vitest run` *(fails: 8 failing tests)*

------
https://chatgpt.com/codex/tasks/task_b_6889ffadaba0832cada9a192930f3b01