### PR TITLE
Improve mobile tap targets

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -249,6 +249,10 @@ html:has(.hide-header) {
 }
 
 @layer base {
+  /* Responsive root font size for improved readability */
+  html {
+    font-size: clamp(1rem, 0.875rem + 0.5vw, 1.125rem);
+  }
   * {
     @apply border-border outline-ring/50;
   }

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -21,7 +21,7 @@ export function MobileNav({ navLinks }: MobileNavProps) {
     <div className="md:hidden">
       <Sheet>
         <SheetTrigger asChild>
-          <Button variant="ghost" size="icon">
+          <Button variant="ghost" size="icon" className="size-11">
             <MenuIcon className="h-6 w-6" />
             <span className="sr-only">Toggle mobile menu</span>
           </Button>
@@ -32,7 +32,7 @@ export function MobileNav({ navLinks }: MobileNavProps) {
               <Link
                 key={link.href}
                 href={link.href}
-                className="text-lg font-medium text-neutral-700 dark:text-white hover:text-teal-600 dark:hover:text-yellow-500 transition-colors"
+                className="text-lg font-medium text-neutral-700 dark:text-white hover:text-teal-600 dark:hover:text-yellow-500 transition-colors py-4"
               >
                 {link.label}
               </Link>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -22,10 +22,11 @@ const buttonVariants = cva(
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
-        icon: "size-9",
+        // Provide larger touch targets on small screens
+        default: "h-11 sm:h-9 px-4 py-2 has-[>svg]:px-3",
+        sm: "h-10 sm:h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-12 sm:h-10 rounded-md px-6 has-[>svg]:px-4",
+        icon: "size-11 sm:size-9",
       },
     },
     defaultVariants: {

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -72,7 +72,7 @@ function SheetContent({
         {...props}
       >
         {children}
-        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none size-11">
           <XIcon className="size-4" />
           <span className="sr-only">Close</span>
         </SheetPrimitive.Close>


### PR DESCRIPTION
## Summary
- increase button sizes on small screens
- pad links in the mobile drawer
- enlarge sheet close button
- scale base font size responsively

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts)*
- `npx vitest run` *(fails: DialogContent accessibility errors)*

------
https://chatgpt.com/codex/tasks/task_b_68894673b9e4832ca6f1edbf06334f3a