### PR TITLE
Apply custom font for header brand text

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 // src/app/layout.tsx
 import type { Metadata } from "next";
 import { Poppins, Merriweather, Uncial_Antiqua } from "next/font/google";
+import localFont from "next/font/local";
 import "./globals.css";
 import { ApolloProvider } from "@/components/providers/apollo-provider";
 
@@ -27,6 +28,14 @@ const uncialAntiqua = Uncial_Antiqua({
   preload: true,
 });
 
+const libreBaskerville = localFont({
+  src: "../../public/fonts/librebaskerville-bold-webfont.woff2",
+  weight: "700",
+  variable: "--font-libre-baskerville",
+  display: "swap",
+  preload: true,
+});
+
 export const metadata: Metadata = {
   title: "STN App",
   description: "A Next.js frontend for WordPress with GraphQL",
@@ -39,7 +48,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${poppins.variable} ${merriweather.variable} ${uncialAntiqua.variable} font-body`}>
+      <body className={`${poppins.variable} ${merriweather.variable} ${uncialAntiqua.variable} ${libreBaskerville.variable} font-body`}>
         <ApolloProvider>
           {children}
         </ApolloProvider>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -32,7 +32,7 @@ export function Header({
             <Logo className="h-10 w-10 sm:h-12 md:h-12 md:w-12" />
           </div>
           <div className="flex flex-col min-w-0">
-            <span className="text-lg sm:text-xl md:text-2xl lg:text-3xl font-bold text-foreground leading-tight group-hover:text-primary transition-colors duration-200 truncate">
+            <span className="text-lg sm:text-xl md:text-2xl lg:text-3xl font-brand font-bold text-foreground leading-tight group-hover:text-primary transition-colors duration-200 truncate">
               St. Nicholas Orthodox Church
             </span>
             <p className="text-xs sm:text-sm md:text-base font-medium text-muted-foreground leading-tight opacity-90">

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,6 +13,7 @@ const config: Config = {
         body: ["var(--font-poppins)", "sans-serif"],
         heading: ["var(--font-merriweather)", "serif"],
         decorative: ["var(--font-uncial-antiqua)", "serif"],
+        brand: ["var(--font-libre-baskerville)", "serif"],
         sans: ["var(--font-poppins)", "sans-serif"],
         serif: ["var(--font-merriweather)", "serif"],
       },


### PR DESCRIPTION
## Summary
- load Libre Baskerville subset font locally
- add brand font family in Tailwind config
- apply brand font to church name in the header

## Testing
- `pnpm exec vitest run` *(fails: jest is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_688a356bee18832cb7e41f801bc6382a