### PR TITLE
fix: revert font assets and fix og card

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -50,7 +50,7 @@ export const metadata: Metadata = {
     type: 'website',
   },
   twitter: {
-    card: 'St. Nicholas Antiochian Churc',
+    card: 'summary_large_image',
     title: 'St. Nicholas Antiochian Orthodox Church - Grand Rapids, MI',
     description: 'Welcome to St. Nicholas Orthodox Church. Experience ancient Christian worship in Grand Rapids. Join us for Divine Liturgy, Vespers, and community.',
     images: ["https://stnicholasgr.com/assests/og-image.jpg"],


### PR DESCRIPTION
## Summary
- revert the layout back to `next/font/google` so the repo no longer needs to ship binary font assets
- remove the `@fontsource` development dependencies that were only required for the local font files
- keep the Twitter card metadata using the supported `summary_large_image` type so Open Graph validation passes

## Testing
- `CI=1 pnpm build` *(fails: Next.js cannot download Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cd6821aa58832c9c39684f9e2bb3f2